### PR TITLE
Fixed compiler errors for Rust 1.73.0

### DIFF
--- a/dinvoke_rs/dinvoke/src/lib.rs
+++ b/dinvoke_rs/dinvoke/src/lib.rs
@@ -812,7 +812,7 @@ pub fn get_function_address_by_ordinal(module_base_address: isize, ordinal: u32)
 /// }
 /// ```
 pub fn ldr_get_procedure_address (module_handle: isize, function_name: &str, ordinal: u32) -> isize {
-
+    #![allow(invalid_reference_casting)]
     unsafe 
     {   
         let ret: Option<i32>;

--- a/dinvoke_rs/dmanager/src/lib.rs
+++ b/dinvoke_rs/dmanager/src/lib.rs
@@ -92,6 +92,7 @@ impl Manager {
 
     pub fn map_module (&mut self, address: i64) -> Result<(),String>
     {
+        #![allow(invalid_reference_casting)]
         unsafe
         {
             if self.payloads.contains_key(&address)
@@ -143,6 +144,7 @@ impl Manager {
 
     pub fn hide (&mut self, address: i64) -> Result<(),String>
     {
+        #![allow(invalid_reference_casting)]
         unsafe
         {
             if self.payloads.contains_key(&address)

--- a/dinvoke_rs/manualmap/src/lib.rs
+++ b/dinvoke_rs/manualmap/src/lib.rs
@@ -588,6 +588,7 @@ pub fn add_runtime_table(pe_info: &PeMetadata, image_ptr: *mut c_void)
 /// pointer to the base address where the module is mapped in memory.
 pub fn set_module_section_permissions(pe_info: &PeMetadata, image_ptr: *mut c_void) -> Result<(),String> 
 {
+    #![allow(invalid_reference_casting)]
     unsafe 
     {
         let base_of_code;


### PR DESCRIPTION
Compiling with Rust version 1.73.0 produced `invalid_reference_casting` errors in several places because `#![deny(invalid_reference_casting)]` is not enabled by default. This PR adds `#![allow(invalid_reference_casting)]` to the the functions that produce those errors.